### PR TITLE
fix: Upgrade helm template for v1.16+ Kubernetes

### DIFF
--- a/aws-ssm/templates/deployment.yaml
+++ b/aws-ssm/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "ssm.fullname" . }}
@@ -15,6 +15,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "ssm.name" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
This is intended to fix AWS-SSM for newer Kubernetes versions, where the `extensions/v1beta1` api group has been deprecated in favour of the new `apps/v11 api group. This has been heavily inspired the the fork from https://github.com/roojoom/aws-ssm/commit/44e4a8a228c3ef961d9246aaf47f2961e7a03af1.