### PR TITLE
feat(chart): configurable polling interval

### DIFF
--- a/aws-ssm/Chart.yaml
+++ b/aws-ssm/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 description: Dynamic secret management for Kubernetes
 name: aws-ssm
-version: 0.1.7
+version: 0.1.8
 appVersion: 0.1.7
 keywords:
   - aws

--- a/aws-ssm/templates/deployment.yaml
+++ b/aws-ssm/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.name }}:{{ .Values.image.tag }}
+          args:
+            - "-interval"
+            - {{ .Values.interval | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.metrics_port }}

--- a/aws-ssm/values.yaml
+++ b/aws-ssm/values.yaml
@@ -32,6 +32,9 @@ master_url: ""
 # Healthcheck port
 metrics_port: 9999
 
+# Polling interval in seconds (-interval flag; binary default 30)
+interval: 30
+
 # Pod Annotations
 podAnnotations: {}
 


### PR DESCRIPTION
Exposes the controller binary's `-interval` flag as a chart value (default `30`, matching the binary default - no behaviour change until a consumer overrides it).

Motivation: the deployed default polls every 30s, which at ~216 managed secrets in opt-workbench-cloud drives ~43M SSM parameter requests/month (the reason the account's paid higher-throughput tier was enabled) and ~13.7M KMS decrypts/month. Cluster repos will set `interval: 120` as an interim cost fix while apps migrate to External Secrets Operator (helm-biarri-common!95).

Chart bumped to 0.1.8 because the Flux HelmReleases use `reconcileStrategy: ChartVersion`.